### PR TITLE
Feather Assignment 16

### DIFF
--- a/linear_algebra/CMakeLists.txt
+++ b/linear_algebra/CMakeLists.txt
@@ -44,6 +44,9 @@ add_executable(test_integrate test_integrate.c)
 add_executable(test_openmp test_openmp.c)
 target_link_libraries(test_openmp OpenMP::OpenMP_C)
 
+add_executable(hello_openmp hello_openmp.c)
+target_link_libraries(hello_openmp OpenMP::OpenMP_C)
+
 add_test(test_vector_dot test_vector_dot)
 add_test(test_vector_add test_vector_add)
 add_test(test_matrix_vector_mul test_matrix_vector_mul)

--- a/linear_algebra/CMakeLists.txt
+++ b/linear_algebra/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(test_average_fortran test_average_fortran.F90)
 target_link_libraries(test_average_fortran OpenMP::OpenMP_Fortran)
 
 add_executable(test_integrate test_integrate.c)
+target_link_libraries(test_integrate OpenMP::OpenMP_C)
 
 add_executable(test_openmp test_openmp.c)
 target_link_libraries(test_openmp OpenMP::OpenMP_C)

--- a/linear_algebra/hello_openmp.c
+++ b/linear_algebra/hello_openmp.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <omp.h>
+
+int
+main(int argc, char **argv)
+{
+	// single-threaded
+	printf("Hi, just starting.\n");
+	// start running multiple threads
+#pragma omp parallel 
+	{
+		int thread_id = omp_get_thread_num();
+		int n_threads = omp_get_num_threads();
+		printf("Hello %d/%d\n", thread_id, n_threads);
+	}
+	// back to single-threaded
+	printf("just about done...\n");
+}

--- a/linear_algebra/test_integrate.c
+++ b/linear_algebra/test_integrate.c
@@ -18,13 +18,17 @@ main(int argc, char **argv)
 
   double tbeg = Wtime();
   double sum = 0.;
-#pragma omp parallel for
-  for (int i = 0; i < N; i++) {
-    double x0 = i * dx;
-    double x1 = (i + 1) * dx;
-    double val = .5 * (f(x0) + f(x1)) * dx;
+#pragma omp parallel
+  {
+    double local_sum = 0.;
+#pragma omp for
+    for (int i = 0; i < N; i++) {
+      double x0 = i * dx;
+      double x1 = (i + 1) * dx;
+      local_sum += .5 * (f(x0) + f(x1)) * dx;;
+    }
 #pragma omp atomic
-    sum += val;
+    sum += local_sum;
   }
   double tend = Wtime();
   printf("sum = %g, took: %g sec\n", sum, tend - tbeg);

--- a/linear_algebra/test_integrate.c
+++ b/linear_algebra/test_integrate.c
@@ -23,7 +23,7 @@ main(int argc, char **argv)
     double x0 = i * dx;
     double x1 = (i + 1) * dx;
     double val = .5 * (f(x0) + f(x1)) * dx;
-#pragma omp critical
+#pragma omp atomic
     sum += val;
   }
   double tend = Wtime();

--- a/linear_algebra/test_integrate.c
+++ b/linear_algebra/test_integrate.c
@@ -18,17 +18,12 @@ main(int argc, char **argv)
 
   double tbeg = Wtime();
   double sum = 0.;
-#pragma omp parallel
-  {
-    double local_sum = 0.;
-#pragma omp for
-    for (int i = 0; i < N; i++) {
-      double x0 = i * dx;
-      double x1 = (i + 1) * dx;
-      local_sum += .5 * (f(x0) + f(x1)) * dx;;
-    }
-#pragma omp atomic
-    sum += local_sum;
+#pragma omp parallel for reduction(+:sum) 
+  for (int i = 0; i < N; i++) {
+    double x0 = i * dx;
+    double x1 = (i + 1) * dx;
+    double val = .5 * (f(x0) + f(x1)) * dx;
+    sum += val;
   }
   double tend = Wtime();
   printf("sum = %g, took: %g sec\n", sum, tend - tbeg);

--- a/linear_algebra/test_integrate.c
+++ b/linear_algebra/test_integrate.c
@@ -18,16 +18,13 @@ main(int argc, char **argv)
 
   double tbeg = Wtime();
   double sum = 0.;
-#pragma omp parallel
-  {
-    double local_sum = 0.;
-#pragma omp for
-    for (int i = 0; i < N; i++) {
-      double x0 = i * dx;
-      double x1 = (i + 1) * dx;
-      local_sum += .5 * (f(x0) + f(x1)) * dx;;
-    }
-    sum += local_sum;
+#pragma omp parallel for
+  for (int i = 0; i < N; i++) {
+    double x0 = i * dx;
+    double x1 = (i + 1) * dx;
+    double val = .5 * (f(x0) + f(x1)) * dx;
+#pragma omp critical
+    sum += val;
   }
   double tend = Wtime();
   printf("sum = %g, took: %g sec\n", sum, tend - tbeg);

--- a/linear_algebra/test_integrate.c
+++ b/linear_algebra/test_integrate.c
@@ -1,26 +1,36 @@
 
+#include "linear_algebra.h"
+
 #include <stdio.h>
 #include <math.h>
 
 static double
 f(double x)
 {
-  return sqrt(1. - x*x);
+  return sqrt(1. - x * x);
 }
 
 int
 main(int argc, char **argv)
 {
-  const int N = 1000;
+  const int N = 1E8;
   double dx = 1. / N;
 
+  double tbeg = Wtime();
   double sum = 0.;
-  for (int i = 0; i < N; i++) {
-    double x0 = i * dx;
-    double x1 = (i+1) * dx;
-    sum += .5 * (f(x0) + f(x1)) * dx;
+#pragma omp parallel
+  {
+    double local_sum = 0.;
+#pragma omp for
+    for (int i = 0; i < N; i++) {
+      double x0 = i * dx;
+      double x1 = (i + 1) * dx;
+      local_sum += .5 * (f(x0) + f(x1)) * dx;;
+    }
+    sum += local_sum;
   }
-  printf("sum = %g\n", sum);
+  double tend = Wtime();
+  printf("sum = %g, took: %g sec\n", sum, tend - tbeg);
 
   return 0;
 }


### PR DESCRIPTION
#### In class exercise: First attempt to avoid the race condition

This approach to avoiding race conditions produces the correct value for the integration and shows good scalability on fishercat.

See [Parallelize test_integrate & avoid race ](https://github.com/unh-hpc-2019/class-14-class-12-will-alex/commit/3409ce2409414622756a4baafc8d42b784f39729)

```
[wgf1@fishercat build]$ OMP_NUM_THREADS=1 ./test_integrate
sum = 0.785398, took: 5.35365 sec
[wgf1@fishercat build]$ OMP_NUM_THREADS=4 ./test_integrate
sum = 0.785398, took: 1.33992 sec
[wgf1@fishercat build]$ OMP_NUM_THREADS=8 ./test_integrate
sum = 0.785398, took: 0.67144 sec
```

#### In-class exercise: Critical sections

This approach still produces the correct value however the performance is significantly reduced. I'm not sure why the performance is impacted so much and gets worse at higher thread counts.

See [Implement critical sections ](https://github.com/unh-hpc-2019/class-14-class-12-will-alex/commit/6bee67b584d95129b703d92a44c233eed4ada4ea)

```
[wgf1@fishercat build]$ OMP_NUM_THREADS=1 ./test_integrate
sum = 0.785398, took: 5.74752 sec
[wgf1@fishercat build]$ OMP_NUM_THREADS=4 ./test_integrate
sum = 0.785398, took: 41.1127 sec
[wgf1@fishercat build]$ OMP_NUM_THREADS=8 ./test_integrate
sum = 0.785398, took: 58.6514 sec
```

#### In-class exercise: Atomic operations

In this approach I used the local sum approach along with the atomic operation to avoid the race condition. I wanted to use the first approach since it shows the best performance but I'm not sure if the atomic operation is strictly necessary. When I tested the the atomic operations alone [here](https://github.com/unh-hpc-2019/class-14-class-12-will-alex/commit/7497fa2927f884573b98177e1650aa7f9b75b27e) I saw an improvement over critical sections but still poor performance (timing data in the commit comments). 

See [Atomic operations with local sum](https://github.com/unh-hpc-2019/class-14-class-12-will-alex/commit/40ece2126b651fc7feb838474587187beaf8bcb6)

```
[wgf1@fishercat build]$ OMP_NUM_THREADS=1 ./test_integrate
sum = 0.785398, took: 5.35797 sec
[wgf1@fishercat build]$ OMP_NUM_THREADS=4 ./test_integrate
sum = 0.785398, took: 1.34357 sec
[wgf1@fishercat build]$ OMP_NUM_THREADS=8 ./test_integrate
sum = 0.785398, took: 0.669933 sec
```

#### In-class exercise: OpenMP reductions

The final approach to avoiding race condition is with OpenMP reductions. using this method I got similar performance as with the local sum and still got the correct value.

See [Add reduction to test_integrate](https://github.com/unh-hpc-2019/class-14-class-12-will-alex/commit/20390d9fcba1ead395d833e6d918e1ba7b0c8a9d)

```
[wgf1@fishercat build]$ OMP_NUM_THREADS=1 ./test_integrate
sum = 0.785398, took: 5.66025 sec
[wgf1@fishercat build]$ OMP_NUM_THREADS=4 ./test_integrate
sum = 0.785398, took: 1.41672 sec
[wgf1@fishercat build]$ OMP_NUM_THREADS=8 ./test_integrate
sum = 0.785398, took: 0.709322 sec
```